### PR TITLE
[#165346115][#165348446] S3 IP Whitelisting and public bucket

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -6,6 +6,7 @@
   "resource_prefix": "paas-s3-broker-",
   "iam_user_path": "/paas-s3-broker/",
   "deploy_env": "london",
+  "iam_ip_restriction_policy_arn": "something",
   "catalog": {
     "services": [
       {

--- a/s3/policy/statement_builder.go
+++ b/s3/policy/statement_builder.go
@@ -28,6 +28,7 @@ type Permissions interface {
 
 type NoPermissions struct{}
 type ReadOnlyPermissions struct{}
+type PublicBucketPermissions struct{}
 type ReadWritePermissions struct{}
 
 func (NoPermissions) Actions() []string {
@@ -38,6 +39,12 @@ func (ReadOnlyPermissions) Actions() []string {
 	return []string{
 		"s3:GetBucketLocation",
 		"s3:ListBucket",
+		"s3:GetObject",
+	}
+}
+
+func (PublicBucketPermissions) Actions() []string {
+	return []string{
 		"s3:GetObject",
 	}
 }

--- a/s3/policy/statement_builder_test.go
+++ b/s3/policy/statement_builder_test.go
@@ -1,6 +1,7 @@
 package policy_test
 
 import (
+	"encoding/json"
 	"github.com/alphagov/paas-s3-broker/s3/policy"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -46,5 +47,30 @@ var _ = Describe("StatementBuilder", func() {
 			"s3:DeleteObject",
 		),
 		)
+	})
+})
+
+var _ = Describe("Statement JSON unmarshaling", func(){
+	It("can unmarshals a statement with a single action", func(){
+		bytes := []byte(`{"effect": "allow", "resource": [], "action": "foo"}`)
+		statement := policy.Statement{}
+
+		err := json.Unmarshal(bytes, &statement)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(statement.Effect).To(Equal("allow"))
+		Expect(statement.Resource).To(BeEmpty())
+		Expect(statement.Action).To(HaveLen(1))
+	})
+
+
+	It("unmarshals an array of strings in to a slice of strings", func() {
+		bytes := []byte(`{"effect": "allow", "resource": [], "action": ["foo", "bar"]}`)
+		statement := policy.Statement{}
+
+		err := json.Unmarshal(bytes, &statement)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(statement.Action).To(HaveLen(2))
+		Expect(statement.Action).To(ConsistOf("foo", "bar"))
 	})
 })

--- a/testing/fixtures/config.json
+++ b/testing/fixtures/config.json
@@ -5,6 +5,7 @@
   "aws_region": "us-east-1",
   "resource_prefix": "test-paas-s3-broker-",
   "iam_user_path": "/test-paas-s3-broker/",
+  "iam_ip_restriction_policy_arn": "__SET_IN_TEST__",
   "deploy_env": "testdev",
   "catalog": {
     "services": [

--- a/testing/fixtures/test_s3_broker_ip_restriction_iam_policy.json.tpl
+++ b/testing/fixtures/test_s3_broker_ip_restriction_iam_policy.json.tpl
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Resource": "*",
+      "Action": "s3:*",
+      "Condition": {
+        "NotIpAddress": {
+          "aws:SourceIp": "{{.ip}}"
+        }
+      }
+    }
+  ]
+}

--- a/testing/integration/broker/broker_suite_test.go
+++ b/testing/integration/broker/broker_suite_test.go
@@ -1,13 +1,128 @@
 package broker_test
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/alphagov/paas-go/broker"
+	"github.com/alphagov/paas-s3-broker/s3"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	uuid "github.com/satori/go.uuid"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
+	"text/template"
+
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+var BrokerSuiteData SuiteData
+type SuiteData struct {
+	LocalhostIAMPolicyArn *string
+	EgressIPIAMPolicyARN  *string
+	AWSRegion             string
+}
+
 func TestBroker(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Broker Suite")
+}
+
+var _ = BeforeSuite(func() {
+	file, err := os.Open("../../fixtures/config.json")
+	Expect(err).ToNot(HaveOccurred())
+	defer file.Close()
+
+	config, err := broker.NewConfig(file)
+	Expect(err).ToNot(HaveOccurred())
+	s3ClientConfig, err := s3.NewS3ClientConfig(config.Provider)
+	Expect(err).ToNot(HaveOccurred())
+
+	sess := session.Must(session.NewSession(&aws.Config{Region: aws.String(s3ClientConfig.AWSRegion)}))
+	iamClient := iam.New(sess)
+	createLocalhostIAMPolicyOutput := createLocalhostPolicy(iamClient)
+	createEgressIPIAMPolicyOutput := createEgressIPPolicy(iamClient)
+
+	BrokerSuiteData = SuiteData{
+		LocalhostIAMPolicyArn: createLocalhostIAMPolicyOutput.Policy.Arn,
+		EgressIPIAMPolicyARN:  createEgressIPIAMPolicyOutput.Policy.Arn,
+		AWSRegion:             s3ClientConfig.AWSRegion,
+	}
+})
+
+var _ = AfterSuite(func() {
+	sess := session.Must(session.NewSession(&aws.Config{Region: aws.String(BrokerSuiteData.AWSRegion)}))
+	iamClient := iam.New(sess)
+
+	for _, arn := range []*string{BrokerSuiteData.LocalhostIAMPolicyArn, BrokerSuiteData.EgressIPIAMPolicyARN} {
+		if arn != nil {
+			_, err := iamClient.DeletePolicy(&iam.DeletePolicyInput{
+				PolicyArn: arn,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+})
+
+func createLocalhostPolicy(iamClient iamiface.IAMAPI) *iam.CreatePolicyOutput {
+	policyString, err := generatePolicy("127.0.0.1/32")
+
+	uniqPolicyName := fmt.Sprintf("TestS3BrokerIpRestrictionLocalhost-%s", uuid.NewV4())
+	createDefaultIAMPolicyOutput, err := iamClient.CreatePolicy(&iam.CreatePolicyInput{
+		Description:    aws.String("Integration Test S3 Broker IP restriction policy - restricted to localhost only"),
+		PolicyDocument: policyString,
+		PolicyName:     aws.String(uniqPolicyName),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	return createDefaultIAMPolicyOutput
+}
+func createEgressIPPolicy(iamClient *iam.IAM) *iam.CreatePolicyOutput {
+	resp, err := http.Get("https://canihazip.com/s")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	Expect(err).ToNot(HaveOccurred())
+
+	ip := strings.TrimSpace(string(body))
+	policyString, err := generatePolicy(fmt.Sprintf("%s/32", ip))
+	Expect(err).ToNot(HaveOccurred())
+
+	uniqPolicyName := fmt.Sprintf("TestS3BrokerIpRestriction%s-%s", ip, uuid.NewV4())
+	createEgressIPIAMPolicyOutput, err := iamClient.CreatePolicy(&iam.CreatePolicyInput{
+		Description: aws.String("Integration Test S3 Broker IP restriction policy - restricted to egress ip only"),
+		PolicyDocument: policyString,
+		PolicyName: aws.String(uniqPolicyName),
+	})
+
+	Expect(err).ToNot(HaveOccurred())
+	return createEgressIPIAMPolicyOutput
+}
+
+func generatePolicy(ip string) (*string, error) {
+	t, err := template.ParseFiles("../../fixtures/test_s3_broker_ip_restriction_iam_policy.json.tpl")
+	if err != nil {
+		return nil, err
+	}
+
+	buffer := bytes.Buffer{}
+	bufferWriter := io.Writer(&buffer)
+	err = t.Execute(bufferWriter, map[string]string{ "ip": ip })
+
+	if err != nil {
+		return nil, err
+	}
+
+	out := buffer.String()
+	return &out, nil
 }


### PR DESCRIPTION
What
----

Quite a big one here...

### IP Whitelisting

Implement IP whitelisting for S3 users, **_changing the current default implementation_**. When a bucket is bound to an app, now, it will only be accessible from apps hosted in the platform.

This can be overridden, by passing a config parameter `-c {"allow_external_access": true}` to `cf bind-service`, allowing the bucket to be accessed from outside of the Diego cells.

### Public Buckets

Buckets can now be created which grants `GetObject` permissions to anonymous users. By default, the buckets are still created with all objects being private, but `-c {"public_bucket": bool}` can be passed to `cf create-service` which will assign these permissions.

Public buckets cannot be made private or vice-versa via self-service. If a bucket is made public by accident, it will have to be deleted and recreated.

How to review
-------------

* Code review
* Rerun the integration and unit tests on build-concourse  / run them locally to ensure they pass.


Who can review
--------------

Not @tnwhitwell or @AP-Hunt 
