### PR TITLE
[#165537156] Enable AES256 encryption at rest

### DIFF
--- a/s3/client.go
+++ b/s3/client.go
@@ -91,6 +91,23 @@ func (s *S3Client) CreateBucket(provisionData provider.ProvisionData) error {
 	if err != nil {
 		return err
 	}
+
+	_, err = s.s3Client.PutBucketEncryption(&s3.PutBucketEncryptionInput{
+		Bucket: aws.String(s.buildBucketName(provisionData.InstanceID)),
+		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
+			Rules: []*s3.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
+						SSEAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	_, err = s.tagBucket(provisionData.InstanceID, []*s3.Tag{
 		{
 			Key:   aws.String("service_instance_guid"),

--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -46,7 +46,22 @@ var _ = Describe("Client", func() {
 			logger,
 		)
 	})
+	Describe("CreateBucket", func() {
+		It("enables encryption at rest", func() {
+			pd := provider.ProvisionData{}
+			s3Client.CreateBucket(pd)
 
+			Expect(s3API.CreateBucketCallCount()).To(Equal(1))
+			Expect(s3API.PutBucketEncryptionCallCount()).To(Equal(1))
+
+			encryptionCallParams := s3API.PutBucketEncryptionArgsForCall(0)
+			encryptionCfg := encryptionCallParams.ServerSideEncryptionConfiguration
+			Expect(len(encryptionCfg.Rules)).To(Equal(1))
+
+			encryptionRule := encryptionCfg.Rules[0]
+			Expect(encryptionRule.ApplyServerSideEncryptionByDefault).ToNot(BeNil())
+		})
+	})
 	Describe("AddUserToBucket", func() {
 		It("manages the user and bucket policy", func() {
 			// Set up fake API


### PR DESCRIPTION
What
----

Enable encryption on s3-broker provisioned buckets at rest.

We are using AES256 as the SSEAlgorithm to avoid having to manage keys with KMS

How to review
-------------

* Code Review
* Build a boshrelease from this branch and run down a pipeline

This has been run through the `tnw` pipeline without error

Who can review
--------------

Not @tnwhitwell or @AP-Hunt 