### PR TITLE
WIP Add s3:{Get,Put}ObjectAcl permissions

### DIFF
--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -198,7 +198,9 @@ var _ = Describe("Client", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedPolicy.Statement).To(HaveLen(1))
 			Expect(updatedPolicy.Statement[0].Action).To(ContainElement("s3:PutObject"))
+			Expect(updatedPolicy.Statement[0].Action).To(ContainElement("s3:PutObjectAcl"))
 			Expect(updatedPolicy.Statement[0].Action).To(ContainElement("s3:GetObject"))
+			Expect(updatedPolicy.Statement[0].Action).To(ContainElement("s3:GetObjectAcl"))
 
 			By("returning the bucket credentials")
 			Expect(bucketCredentials).To(Equal(s3.BucketCredentials{
@@ -254,7 +256,9 @@ var _ = Describe("Client", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedPolicy.Statement).To(HaveLen(1))
 			Expect(updatedPolicy.Statement[0].Action).ToNot(ContainElement("s3:PutObject"))
+			Expect(updatedPolicy.Statement[0].Action).ToNot(ContainElement("s3:PutObjectAcl"))
 			Expect(updatedPolicy.Statement[0].Action).To(ContainElement("s3:GetObject"))
+			Expect(updatedPolicy.Statement[0].Action).To(ContainElement("s3:GetObjectAcl"))
 
 			By("returning the bucket credentials")
 			Expect(bucketCredentials).To(Equal(s3.BucketCredentials{

--- a/s3/policy/statement_builder.go
+++ b/s3/policy/statement_builder.go
@@ -65,6 +65,7 @@ func (ReadOnlyPermissions) Actions() []string {
 		"s3:GetBucketLocation",
 		"s3:ListBucket",
 		"s3:GetObject",
+		"s3:GetObjectAcl",
 	}
 }
 
@@ -79,7 +80,9 @@ func (ReadWritePermissions) Actions() []string {
 		"s3:GetBucketLocation",
 		"s3:ListBucket",
 		"s3:GetObject",
+		"s3:GetObjectAcl",
 		"s3:PutObject",
+		"s3:PutObjectAcl",
 		"s3:DeleteObject",
 	}
 }

--- a/s3/policy/statement_builder_test.go
+++ b/s3/policy/statement_builder_test.go
@@ -23,6 +23,7 @@ var _ = Describe("StatementBuilder", func() {
 		Expect(actualStatement.Resource).To(ContainElement("arn:aws:s3:::some-instance-id/*"))
 		Expect(actualStatement.Action).To(ConsistOf(
 			"s3:GetObject",
+			"s3:GetObjectAcl",
 			"s3:GetBucketLocation",
 			"s3:ListBucket"),
 		)
@@ -43,7 +44,9 @@ var _ = Describe("StatementBuilder", func() {
 			"s3:GetBucketLocation",
 			"s3:ListBucket",
 			"s3:GetObject",
+			"s3:GetObjectAcl",
 			"s3:PutObject",
+			"s3:PutObjectAcl",
 			"s3:DeleteObject",
 		),
 		)


### PR DESCRIPTION
This will allow people to make certain objects more acessible than their
buckets (e.g. service public files from a private bucket).