### PR TITLE
[#169891611]: Add GetBucketCORS and PutBucketCORS to policies

### DIFF
--- a/s3/policy/statement_builder.go
+++ b/s3/policy/statement_builder.go
@@ -64,6 +64,7 @@ func (ReadOnlyPermissions) Actions() []string {
 	return []string{
 		"s3:GetBucketLocation",
 		"s3:ListBucket",
+		"s3:GetBucketCORS",
 		"s3:GetObject",
 	}
 }
@@ -78,6 +79,8 @@ func (ReadWritePermissions) Actions() []string {
 	return []string{
 		"s3:GetBucketLocation",
 		"s3:ListBucket",
+		"s3:GetBucketCORS",
+		"s3:PutBucketCORS",
 		"s3:GetObject",
 		"s3:PutObject",
 		"s3:DeleteObject",

--- a/s3/policy/statement_builder_test.go
+++ b/s3/policy/statement_builder_test.go
@@ -24,6 +24,7 @@ var _ = Describe("StatementBuilder", func() {
 		Expect(actualStatement.Action).To(ConsistOf(
 			"s3:GetObject",
 			"s3:GetBucketLocation",
+			"s3:GetBucketCORS",
 			"s3:ListBucket"),
 		)
 	})
@@ -42,6 +43,8 @@ var _ = Describe("StatementBuilder", func() {
 		Expect(actualStatement.Action).To(ConsistOf(
 			"s3:GetBucketLocation",
 			"s3:ListBucket",
+			"s3:GetBucketCORS",
+			"s3:PutBucketCORS",
 			"s3:GetObject",
 			"s3:PutObject",
 			"s3:DeleteObject",


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html

> Cross-origin resource sharing (CORS) defines a way for client web
> applications that are loaded in one domain to interact with resources in
> a different domain. With CORS support, you can build rich client-side
> web applications with Amazon S3 and selectively allow cross-origin
> access to your Amazon S3 resources.

Enabling these permissions on the policies that tenant applications get
will allow people to choose whether to enable CORS on their buckets or
not. This is useful for things like file uploads that go directly to S3,
instead of being proxied through an app on the platform.