### PR TITLE
Always allow the cf re-bind functionality

### DIFF
--- a/s3/client.go
+++ b/s3/client.go
@@ -488,7 +488,10 @@ func (s *S3Client) RemoveUserFromBucketAndDeleteUser(bindingID, bucketName strin
 	updatedPolicy, err := policy.RemoveUserFromPolicy(*getBucketPolicyOutput.Policy, username)
 	if err != nil {
 		logger.Error("remove-user-from-policy", err)
-		return err
+
+		if !strings.Contains(err.Error(), "could not find a policy statement for user") {
+			return err
+		}
 	}
 
 	logger.Info("policy-statements", lager.Data{"bucket": fullBucketName, "count": len(updatedPolicy.Statement)})

--- a/s3/policy/policy_builder.go
+++ b/s3/policy/policy_builder.go
@@ -54,11 +54,11 @@ func RemoveUserFromPolicy(existingPolicy string, userArnSuffix string) (PolicyDo
 		}
 	}
 
-	if len(maintainedStatements) == len(policyDoc.Statement) {
-		return PolicyDocument{}, fmt.Errorf("could not find a policy statement for user %s", userArnSuffix)
-	}
-
+	statementsCount := len(policyDoc.Statement)
 	policyDoc.Statement = maintainedStatements
+	if len(maintainedStatements) == statementsCount {
+		return policyDoc, fmt.Errorf("could not find a policy statement for user %s", userArnSuffix)
+	}
 
 	return policyDoc, nil
 }


### PR DESCRIPTION
## What

On number of occasions, we've faced the leaked S3 access keys. When this
happens, AWS is removing our set of statements on the user policy. This
causes the broker, unable to perform unbind action, as there is no
statement to delete.

We want to relax that functionality, so that users are always empowered
to re-bind the service causing the access token rotation, without
extreme measures and the GOV.UK PaaS Support intervention.

This change involves very weird practice, of returning both error and
the result. But then checking the error kind and deciding whether or not
to kill the action, or simply log the error and carry on. Its only
purpose, is to leave the function as pure as possible, and not have a
dependency on the logger.

## How to review

* Sanity check
* Code review
* Deploy to your dev env
* Create S3 service
* Bind S3 service to any app
* Log into AWS console, navigate to IAM user for that S3 bucket and remove the policy statement(s)
* Attempt to unbind and rebind the service
* Experience no errors
* Validate AWS console has "healed" itself by recreating the user with policy statement(s)
