### PR TITLE
[WIP] Fix unbinding failure when there are multiple bindings

### DIFF
--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -552,7 +552,10 @@ var _ = Describe("Client", func() {
 									"arn:aws:s3:::gds-paas-s3-broker-bucketName/*"
 								],
 								"Principal": {
-									"AWS": "some-arn"
+									"AWS": [
+										"some-arn",
+										"some-other-arn"
+									]
 								}
 							}
 						]


### PR DESCRIPTION
## What

So far this PR alters a test to expose [a bug that a user has discovered](https://govuk.zendesk.com/agent/tickets/4296600). When you have multiple bindings, the `Principal.AWS` field of a policy statement can be a list of IAM user ARNs. But right now we require it to deserialise to a single string, and so an error happens. This prevents unbinding (and possibly other operations too.)

This PR needs to then fix the problem.

It looks like we try to create a new IAM policy statement for each new binding. But AWS may then be deduplicating them to have fewer policy statements. We can't control AWS's behaviour so we'll have to accept `Principal.AWS` as being either a string or an array of strings.