### PR TITLE
Change the IP provider

### DIFF
--- a/testing/integration/broker/broker_suite_test.go
+++ b/testing/integration/broker/broker_suite_test.go
@@ -105,7 +105,7 @@ func createLocalhostPolicy(iamClient iamiface.IAMAPI) *iam.CreatePolicyOutput {
 	return createDefaultIAMPolicyOutput
 }
 func createEgressIPPolicy(iamClient *iam.IAM) *iam.CreatePolicyOutput {
-	resp, err := http.Get("https://canihazip.com/s")
+	resp, err := http.Get("https://wtfismyip.com/text")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 


### PR DESCRIPTION
## What

The old IP provider has disappeared from the internet, causing our tests
to fail.

We found a new one, well knowing it can disappear too. But we need the
tests passing in the mean time...