### PR TITLE
Prevent "Invalid Auth Token" error.

### DIFF
--- a/cmd/costs_by_month/README.md
+++ b/cmd/costs_by_month/README.md
@@ -20,8 +20,8 @@ go build -o costs_by_month
    service instances exist;
 3. ```
    ./costs_by_month \
-     --cf-api-url https://api.cloud.service.gov.uk \
-     --cf-api-token "$(cf oauth-token)"
+     --cf-api-token "$(cf oauth-token)" \
+     --cf-api-url https://api.london.cloud.service.gov.uk
    ```
 
 That should output something like:

--- a/cmd/costs_by_month/main.go
+++ b/cmd/costs_by_month/main.go
@@ -26,6 +26,8 @@ func main() {
 	flag.BoolVar(&useCsv, "use-csv", false, "Whether to output as CSV")
 	flag.Parse()
 
+	// Trim off any trailing whitespace, in case user has specified cf-api-token as the last command-line argument.
+	cfApiToken = strings.TrimSpace(cfApiToken)
 	cf, err := cfClient(cfApiUrl, cfApiToken)
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
If a user specifies the token as the last command line argument, and the command line ends in a space, then Cloudfoundry returns an "Invalid Auth Token" response.