### PR TITLE
Add makefile option to bosh scp built binary to an existing bosh environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.idea
+
+# Temporary Build Files
+amd64/*

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,12 @@ generate:
 	counterfeiter -o s3/fakes/fake_s3_api.go vendor/github.com/aws/aws-sdk-go/service/s3/s3iface/ S3API
 	counterfeiter -o s3/fakes/fake_iam_api.go vendor/github.com/aws/aws-sdk-go/service/iam/iamiface/ IAMAPI
 	go generate ./...
+
+.PHONY: build_amd64
+build_amd64:
+	mkdir -p amd64
+	GOOS=linux GOARCH=amd64 go build -o amd64/s3-broker
+
+.PHONY: bosh_scp
+bosh_scp: build_amd64
+	./scripts/bosh-scp.sh

--- a/README.md
+++ b/README.md
@@ -148,3 +148,13 @@ The integration tests will require you to have at least the IAM permissions list
 ## `costs_by_month` utility
 
 In `cmd/costs_by_month/README.md` you can find instructions for calculating the cost of tenant S3 buckets over the last few months.
+
+## Patching an existing bosh environment
+
+If you want to patch an existing bosh environment you can run the following command:
+
+```
+make bosh_scp
+```
+
+This requires an existing bosh session to be established beforehand.

--- a/scripts/bosh-scp.sh
+++ b/scripts/bosh-scp.sh
@@ -1,0 +1,31 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+function run_command() {
+    local command=$1
+    local message=$2
+
+    echo -n "${message}... "
+
+    if ! output=$(bash -c "${command}" 2>&1); then
+        echo -e "failed.\n\n"
+        echo "Command Failed: ${command}"
+        echo ""
+        echo "Output: ${output}"
+        exit 1
+    fi
+    echo "done."
+}
+
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
+command -v bosh >/dev/null 2>&1 || { echo >&2 "bosh is required but it's not installed.  Aborting."; exit 1; }
+command -v cut >/dev/null 2>&1 || { echo >&2 "cut is required but it's not installed.  Aborting."; exit 1; }
+
+bosh vms --json | jq -r '.Tables[0].Rows[] | select(.instance|startswith("s3_broker/")) | .instance' | while read -r instance; do
+    run_command "bosh ssh ${instance} sudo monit stop s3-broker" "stopping s3-broker on ${instance}"
+    run_command "bosh scp ./amd64/s3-broker ${instance}:/tmp/s3-broker" "copying s3-broker binary to tmp on ${instance}"
+    run_command "bosh ssh ${instance} sudo mv /tmp/s3-broker /var/vcap/packages/s3-broker/bin/paas-s3-broker" "moving s3-broker binary from tmp to packages on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit start s3-broker" "starting s3-broker on ${instance}"
+done
+


### PR DESCRIPTION
What
----

Add a make bosh_scp target for building and deploying into an existing environment.

Why
----

This allows a more rapid way to deploy and test your changes in an existing environment

How to review
-------------

Test it
