### PR TITLE
S3 broker security changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The IAM role for the broker must include at least the following policy:
                 "s3:CreateBucket",
                 "s3:DeleteBucket",
                 "s3:PutBucketPolicy",
+                "s3:PutBucketPublicAccessBlock",
                 "s3:DeleteBucketPolicy",
                 "s3:GetBucketPolicy",
                 "s3:PutBucketTagging",


### PR DESCRIPTION
Starting in April 2023 Amazon S3 will change the default security configuration for all new S3 buckets. For new buckets created after this date, S3 Block Public Access will be enabled, and S3 access control lists (ACLs) will be disabled.

This PR makes sure S3 Block Public Access is enabled beforehand and gets removed when creating a public bucket.