### PR TITLE
golang: 1.18 -> 1.20

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,7 +1,7 @@
 name: Run tests
 on: [push, pull_request]
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: "1.20"
 jobs:
 
   build:

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.18-stretch
+    tag: "1.20"
 inputs:
   - name: repo
 run:

--- a/go.mod
+++ b/go.mod
@@ -58,4 +58,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.18
+go 1.20


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184967033

Deliberately not including bump of deps because that balloons with problems we don't have time for. See my `ris-deps-update` branch if interested.