### PR TITLE
bucket policies: grant `GetObjectTagging` to binding users

### DIFF
--- a/s3/policy/statement_builder.go
+++ b/s3/policy/statement_builder.go
@@ -68,6 +68,7 @@ func (ReadOnlyPermissions) Actions() []string {
 		"s3:ListBucket",
 		"s3:GetBucketCORS",
 		"s3:GetObject",
+		"s3:GetObjectTagging",
 	}
 }
 
@@ -86,6 +87,7 @@ func (ReadWritePermissions) Actions() []string {
 		"s3:GetObject",
 		"s3:PutObject",
 		"s3:DeleteObject",
+		"s3:GetObjectTagging",
 	}
 }
 

--- a/s3/policy/statement_builder_test.go
+++ b/s3/policy/statement_builder_test.go
@@ -26,8 +26,9 @@ var _ = Describe("StatementBuilder", func() {
 			"s3:GetObject",
 			"s3:GetBucketLocation",
 			"s3:GetBucketCORS",
-			"s3:ListBucket"),
-		)
+			"s3:ListBucket",
+			"s3:GetObjectTagging",
+		))
 	})
 
 	It("should build a statement that gives read and write permissions", func() {
@@ -49,8 +50,8 @@ var _ = Describe("StatementBuilder", func() {
 			"s3:GetObject",
 			"s3:PutObject",
 			"s3:DeleteObject",
-		),
-		)
+			"s3:GetObjectTagging",
+		))
 	})
 })
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186090782

This will allow tenants to `sync` buckets via the awscli.

## How to test

:eyes: unit tests

See this being deployed to dev03 and passing the updated custom-broker-acceptance-tests https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/custom-acceptance-tests/builds/21